### PR TITLE
Update links to norminette v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,8 @@ Tests for the new cursus (from october 2019)
 * [42tools](https://github.com/solareenlo/42tools) - solareenlo
 * [Intra 42 android app](https://play.google.com/store/apps/details?id=com.paulvarry.intra42&hl=fr), 
   [Github of the app](https://github.com/pvarry/intra42)
-* [norminette from home](https://github.com/42Paris/norminette) - [Paris]
+* [norminette v3 from home](https://github.com/42School/norminette) - [Paris]
+* [norminette v3 highlighter for vscode](https://github.com/Mariusmivw/vscode-42-norminette-3-highlighter)
 * [header from home](https://github.com/pbondoer/vim-42header) - [Paris]
 * [header from home - VS Code](https://marketplace.visualstudio.com/items?itemName=kube.42header&ssr=false#overview) - [Paris]
 


### PR DESCRIPTION
Update 'norminette from home' link to the v3 version. And add a norminette highlighter for vscode.